### PR TITLE
this adds an 'order' to the front matter that allows you to put the f…

### DIFF
--- a/src/site/documentation/components/creating-new-components.njk
+++ b/src/site/documentation/components/creating-new-components.njk
@@ -1,7 +1,8 @@
 ---
-title: 1. Creating a new component
+title: Creating a new component
 date: 2019-04-09 12:24:50
 layout: layouts/documentation.njk
+order: 1
 ---
 
 This codebase includes a folder and file creation tool. It allows you to quickly create all the required files to make a component. It gives you the option to create am element, block, or container.

--- a/src/site/documentation/components/deprecating-components.njk
+++ b/src/site/documentation/components/deprecating-components.njk
@@ -1,7 +1,8 @@
 ---
-title: 3. Deprecating components
+title: Deprecating components
 date: 2019-04-09 12:24:50
 layout: layouts/documentation.njk
+order: 3;
 ---
 
 Inevitably code will be replaced and improved, leaving components stale and or outdated. So we should tell developers to not use them, here's how.

--- a/src/site/documentation/components/updating-a-component.njk
+++ b/src/site/documentation/components/updating-a-component.njk
@@ -1,7 +1,8 @@
 ---
-title: 2. Updating, versioning a component
+title: Updating, versioning a component
 date: 2019-04-09 12:24:50
 layout: layouts/documentation.njk
+order: 2
 ---
 
 Like the Visual Framework 2.0, components follow [semantic versioning](https://semver.org/) by increasing their full version number every time they have breaking changes.

--- a/src/site/documentation/getting-started/code-of-conduct.njk
+++ b/src/site/documentation/getting-started/code-of-conduct.njk
@@ -1,7 +1,8 @@
 ---
-title: 1. Code of conduct
+title: Code of conduct
 date: 2019-04-09 12:24:50
 layout: layouts/documentation.njk
+order: 4
 ---
 
 We don't yet have a full policy but, in general: be nice, respectful

--- a/src/site/documentation/getting-started/naming.njk
+++ b/src/site/documentation/getting-started/naming.njk
@@ -1,7 +1,8 @@
 ---
-title: 4. Naming things
+title: Naming things
 date: 2019-04-09 12:24:50
 layout: layouts/documentation.njk
+order: 4
 ---
 
 <p class="vf-lede">The Visual Framework uses a dual approach for the naming of things.</p>

--- a/src/site/documentation/getting-started/pull-requests.njk
+++ b/src/site/documentation/getting-started/pull-requests.njk
@@ -1,7 +1,8 @@
 ---
-title: 5. Making your first Pull Request
+title: Making your first Pull Request
 date: 2019-04-09 12:24:50
 layout: layouts/documentation.njk
+order: 5
 ---
 
 To contribute code back, you'll need to make a PR ([Pull Request](https://help.github.com/en/articles/about-pull-requests)),

--- a/src/site/documentation/getting-started/setting-up.njk
+++ b/src/site/documentation/getting-started/setting-up.njk
@@ -1,7 +1,8 @@
 ---
-title: 3. Setting up your development environment
+title: Setting up your development environment
 date: 2019-04-09 12:24:50
 layout: layouts/documentation.njk
+order: 3
 ---
 
 To develop the Visual Framework your will need some software.

--- a/src/site/documentation/getting-started/structure.njk
+++ b/src/site/documentation/getting-started/structure.njk
@@ -1,7 +1,8 @@
 ---
-title: 2. Structure of the Visual Framework
+title: Structure of the Visual Framework
 date: 2019-04-09 12:24:50
 layout: layouts/documentation.njk
+order: 2
 ---
 
 ## Design decisions and tokens

--- a/src/site/documentation/index.njk
+++ b/src/site/documentation/index.njk
@@ -49,13 +49,13 @@ first of all: thanks!
 We welcome ideas, bug reports, opinions and pull requests. Telling the maintainers
 why you want or have done something is always very helpful.
 
-<ul>
-{%- for page in collections['getting started'] | sort(page, true, false, 'url') %}
+<ol>
+{%- for page in collections['getting started'] | sort(false, true, 'order') %}
 {%- if page.data.layout %}
   <li><a href="{{ page.url | url }}">{{ page.data.title }}</a></li>
 {%- endif %}
 {%- endfor %}
-</ul>
+</ol>
 
 </div>
 </section>
@@ -72,13 +72,13 @@ why you want or have done something is always very helpful.
 Once you've set up the VF Core locally or made a new design system, you'll want to
 extend it by creating components to add new charts, tables or other types of functionality.
 
-<ul>
-{%- for page in collections['contributing components'] | sort(false, true, 'url') %}
+<ol>
+{%- for page in collections['contributing components'] | sort(false, true, 'order') %}
 {%- if page.data.layout %}
   <li><a href="{{ page.url | url }}">{{ page.data.title }}</a></li>
 {%- endif %}
 {%- endfor %}
-</ul>
+</ol>
 
 </div>
 </section>


### PR DESCRIPTION
I noticed that on the [documentation page](https://visual-framework.github.io/vf-welcome/documentation/) there was an unordered list with a numbered list (the numbers being in the title used).

This update does two things, one of which is probably 'optional'

- adds an `order` to the yaml front matter which is parsed to determine the order of links for the list
- turns the `ul` to `ol` -- this one may be unrequired - as it's not _really_ an ordered list to me, and I think the original use of numbers was just to order the files in a suggested order - rather than it being a strict progression. 

